### PR TITLE
cron-whitelist: follow-up digest for opa-ff

### DIFF
--- a/cron-whitelist.json
+++ b/cron-whitelist.json
@@ -114,6 +114,12 @@
 				"digests": {
 					"/etc/cron.daily/opa-cablehealth": "sha256:7e837d9ba6f1361d63bdb5e716e1f5ce9ac774f22fa79ef32d51a9e0c925c11b"
 				}
+			},
+			"sr#813053": {
+				"comment": "just a version string changed in the script",
+				"digests": {
+					"/etc/cron.daily/opa-cablehealth": "sha256:56fda31f1bfbda32d628250ed17a72ef04823b120ad1449045b380b9983d86e8"
+				}
 			}
 		}
 	},


### PR DESCRIPTION
There's no review bug for this one since it's a non-logical change. See
obs sr#813053.