### PR TITLE
opa-ff: add wildcard whitelisting (bsc#1174464)

### DIFF
--- a/cron-whitelist.json
+++ b/cron-whitelist.json
@@ -120,6 +120,12 @@
 				"digests": {
 					"/etc/cron.daily/opa-cablehealth": "sha256:56fda31f1bfbda32d628250ed17a72ef04823b120ad1449045b380b9983d86e8"
 				}
+			},
+			"bsc#1174464": {
+				"comment": "finally a wildcard whitelisting since there's a version string encoded in the script",
+				"digests": {
+					"/etc/cron.daily/opa-cablehealth": "skip:<none>"
+				}
 			}
 		}
 	},


### PR DESCRIPTION
This script contains dynamic no-op content in comments that changes with
every release. We would either need to whitelisting each of these no-op
changes or we would need to adapt our digesting mechanism to skip '#'
comment lines. Since this instance if currently the only case of this
I'm taking the wildcard whitelisting route for the moment.