### PR TITLE
Introduce new metadata based whitelistings for device files and world-writable files

### DIFF
--- a/device-files-whitelist.json
+++ b/device-files-whitelist.json
@@ -1,0 +1,29 @@
+{
+	"bind-chrootenv": {
+		"audits": {
+			"bsc#1174642": {
+				"comment": "Chroot duplicates of some uncritical character devices. urandom was historically packaged non-world-writable, probably to avoid the rpmlint error triggering.",
+				"meta": {
+					"/var/lib/named/dev/null": {
+						"type": "c",
+						"mode": "0666",
+						"dev": "1,3",
+                                                "owner": "root:root"
+					},
+					"/var/lib/named/dev/random": {
+						"type": "c",
+						"mode": "0666",
+						"dev": "1,8",
+						"owner": "root:root"
+					},
+					"/var/lib/named/dev/urandom": {
+						"type": "c",
+						"mode": "0660",
+						"dev": "1,9",
+                                                "owner": "root:root"
+					}
+				}
+			}
+		}
+	}
+}

--- a/verify.py
+++ b/verify.py
@@ -101,7 +101,12 @@ def checkParsing(path):
 	if not whitelisting:
 		whitelisting = fetchWhitelistingModule()
 
-	parser = whitelisting.WhitelistParser(path)
+	meta_whitelists = ("device-files-whitelist.json", "world-writable-whitelist.json")
+
+	if os.path.basename(path) in meta_whitelists:
+		parser = whitelisting.MetaWhitelistParser(path)
+	else:
+		parser = whitelisting.DigestWhitelistParser(path)
 
 	try:
 		entries = parser.parse()

--- a/world-writable-whitelist.json
+++ b/world-writable-whitelist.json
@@ -1,0 +1,64 @@
+{
+	"bind-chrootenv": {
+		"audits": {
+			"bsc#1174642": {
+				"comment": "Chroot duplicate of the log socket. Packaged as %ghost, therefore 'appears' as a regular file.",
+				"meta": {
+					"/var/lib/named/dev/log": {
+						"type": "-",
+						"mode": "0666",
+                                                "owner": "root:root"
+					}
+				}
+			}
+		}
+	},
+	"filesystem": {
+		"audits": {
+			"bsc#1174642": {
+				"comment": "Public standard sticky-bit directories",
+				"meta": {
+					"/tmp": {
+						"type": "d",
+						"mode": "1777",
+						"owner": "root:root"
+					},
+					"/var/tmp": {
+						"type": "d",
+						"mode": "1777",
+						"owner": "root:root"
+					},
+					"/var/spool/mail": {
+						"type": "d",
+						"mode": "1777",
+						"owner": "root:root"
+					},
+					"/tmp/.X11-unix": {
+						"type": "d",
+						"mode": "1777",
+						"owner": "root:root"
+					},
+					"/tmp/.ICE-unix": {
+						"type": "d",
+						"mode": "1777",
+						"owner": "root:root"
+					}
+				}
+			}
+		}
+	},
+	"nscd": {
+		"audits": {
+			"bsc#1174642": {
+				"comment": "nss caching daemon socket. is packaged as %ghost, therefore 'appears' to be a regular file.",
+				"meta": {
+					"/run/nscd/socket": {
+						"type": "-",
+						"mode": "0666",
+						"owner": "root:root"
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is related to openSUSE/rpmlint-checks#63. It adjust the documentation and verification to support the new whitelisting type. It also introduces the actual whitelists for currently packaged device files and world-writable files in Factory.