### PR TITLE
device-files-whitelist: fix mode of named: urandom dev file

### DIFF
--- a/device-files-whitelist.json
+++ b/device-files-whitelist.json
@@ -18,7 +18,7 @@
 					},
 					"/var/lib/named/dev/urandom": {
 						"type": "c",
-						"mode": "0660",
+						"mode": "0664",
 						"dev": "1,9",
                                                 "owner": "root:root"
 					}

--- a/world-writable-whitelist.json
+++ b/world-writable-whitelist.json
@@ -7,7 +7,7 @@
 					"/var/lib/named/dev/log": {
 						"type": "-",
 						"mode": "0666",
-                                                "owner": "root:root"
+						"owner": "root:root"
 					}
 				}
 			}


### PR DESCRIPTION
The currently packaged mode still covers the world-readable bit.