### PR TITLE
add a script to convert files to formatted TOML

### DIFF
--- a/json-to-toml.py
+++ b/json-to-toml.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import pathlib
+
+import toml
+
+def convert(path):
+    with path.open(encoding="utf-8") as f:
+        d = json.load(f)
+    out = []
+    first = True
+
+    expected_parse = {}
+
+    for package, audits in d.items():
+        if first:
+            first = False
+        else:
+            out.append("")
+            out.append("")
+        out.append(f"[{package}]")
+
+        expected_parse[package] = {}
+
+        assert audits.keys() == {'audits'}, "unhandled keys in JSON"
+        for bug, info in audits['audits'].items():
+            expected_parse[package][bug] = info
+
+            # remove comment, so that expected_parse doesn't contain comments and the next()-thing below works
+            comment = info.pop('comment', None)
+
+            assert (info.keys() == {'meta'} or info.keys() == {'digests'}), \
+                    f"unhandled keys {info.keys()} in JSON"
+
+            name, data = next(iter(info.items()))
+            out.append(f'    [{package}.{repr(bug)}.{name}]')
+            if comment:
+                out.append(f"        # {comment}")
+
+            for mpath, val in data.items():
+                if isinstance(val, dict):
+                    val = "{ " + ", ".join(f"{key} = {repr(val)}" for key, val in val.items()) + " }"
+                elif isinstance(val, str):
+                    val = repr(val)
+                else:
+                    assert False, "unknown type"
+                out.append(f'        {repr(mpath)} = {val}')
+
+    # make sure the TOML isn't invalid
+    t = toml.loads("\n".join(out))
+    assert expected_parse == t
+
+    with path.with_suffix(".toml").open("w", encoding="utf-8") as f:
+        f.write("\n".join(out))
+
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser(description="TOML Converter")
+    p.add_argument("files", metavar="FILE", nargs='+',
+                   help="JSON files to convert. TOML output files will be in the same location with .toml suffix.")
+    args = p.parse_args()
+
+    for fname in args.files:
+        convert(pathlib.Path(fname))


### PR DESCRIPTION
For rpm-software-management/rpmlint#439 we need to switch to TOML. To be able to keep working without interruption this PR adds a script that converts the current JSON to decently formatted TOML. The script is a bit hacky, but it makes sure that - except for comments - the parsed TOML files are identical to the JSON input.

The output of this script are TOML files looking like this:

```toml

#### sarg ####
  [sarg.audits."bsc#1150554"]
  # builds statistics based on Squid logfile metadata. include sarg-reports which is SUSE specific and important for privilege dropping.

    [sarg.audits."bsc#1150554".digests]
    "/etc/cron.daily/suse.de-sarg" = "sha256:d536dc68e198189149048a907ea6d56a7ee9fc732ae8fec5a4072ad06640e359"
    "/etc/cron.monthly/suse.de-sarg" = "sha256:d536dc68e198189149048a907ea6d56a7ee9fc732ae8fec5a4072ad06640e359"
    "/etc/cron.weekly/suse.de-sarg" = "sha256:d536dc68e198189149048a907ea6d56a7ee9fc732ae8fec5a4072ad06640e359"
    "/usr/sbin/sarg-reports" = "sha256:00ad25400bdc2031cd09f9b8f9e56c448c93b6b89a702d36dce6a385d79e637c"
```


```toml
#### filesystem ####
  [filesystem.audits."bsc#1174642"]
  # Public standard sticky-bit directories

    [filesystem.audits.'bsc#1174642'.meta]
        '/tmp' = { type = 'd', mode = '1777', owner = 'root:root' }
        '/var/tmp' = { type = 'd', mode = '1777', owner = 'root:root' }
        '/var/spool/mail' = { type = 'd', mode = '1777', owner = 'root:root' }
        '/tmp/.X11-unix' = { type = 'd', mode = '1777', owner = 'root:root' }
        '/tmp/.ICE-unix' = { type = 'd', mode = '1777', owner = 'root:root' }
```


As far as I am concerned, we could also drop the dictionary nesting level "audits", since it's the only sub-key to the package name that exists. Technically, "digests" and "meta" are also redundant (the rpmlint check already knows which of these it expects).